### PR TITLE
Requested changes

### DIFF
--- a/HiP-ThumbnailService.sln.DotSettings
+++ b/HiP-ThumbnailService.sln.DotSettings
@@ -1,0 +1,7 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CollectionNeverUpdated_002EGlobal/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CollectionNeverUpdated_002ELocal/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PrivateFieldCanBeConvertedToLocalVariable/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedTypeParameter/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleMultipleEnumeration/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedAutoPropertyAccessor_002EGlobal/@EntryIndexedValue">SUGGESTION</s:String></wpf:ResourceDictionary>

--- a/HiP-ThumbnailService/Arguments/CreationArgs.cs
+++ b/HiP-ThumbnailService/Arguments/CreationArgs.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
-
-namespace PaderbornUniversity.SILab.Hip.ThumbnailService.Arguments
+﻿namespace PaderbornUniversity.SILab.Hip.ThumbnailService.Arguments
 {
     public class CreationArgs
     {

--- a/HiP-ThumbnailService/Arguments/RequestedImageFormat.cs
+++ b/HiP-ThumbnailService/Arguments/RequestedImageFormat.cs
@@ -7,7 +7,6 @@ namespace PaderbornUniversity.SILab.Hip.ThumbnailService.Arguments
     public enum RequestedImageFormat
     {
         Jpeg, Png
-
     }
 
     public static class RequestImageFormatUtils
@@ -21,7 +20,7 @@ namespace PaderbornUniversity.SILab.Hip.ThumbnailService.Arguments
                 case RequestedImageFormat.Png:
                     return ImageFormats.Png;
                 default:
-                    throw new ArgumentOutOfRangeException("Unexpected image format");
+                    throw new ArgumentOutOfRangeException(nameof(format), "Unexpected image format");
             }
 
         }

--- a/HiP-ThumbnailService/Arguments/RequestedImageFormat.cs
+++ b/HiP-ThumbnailService/Arguments/RequestedImageFormat.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats;
 
 namespace PaderbornUniversity.SILab.Hip.ThumbnailService.Arguments
 {
@@ -10,14 +12,14 @@ namespace PaderbornUniversity.SILab.Hip.ThumbnailService.Arguments
 
     public static class RequestImageFormatUtils
     {
-        public static string GetExtension(this RequestedImageFormat format)
+        public static IImageFormat GetExtension(this RequestedImageFormat format)
         {
             switch (format)
             {
                 case RequestedImageFormat.Jpeg:
-                    return "jpeg";
+                    return ImageFormats.Jpeg;
                 case RequestedImageFormat.Png:
-                    return "png";
+                    return ImageFormats.Png;
                 default:
                     throw new ArgumentOutOfRangeException("Unexpected image format");
             }

--- a/HiP-ThumbnailService/Arguments/RequestedImageFormat.cs
+++ b/HiP-ThumbnailService/Arguments/RequestedImageFormat.cs
@@ -12,7 +12,7 @@ namespace PaderbornUniversity.SILab.Hip.ThumbnailService.Arguments
 
     public static class RequestImageFormatUtils
     {
-        public static IImageFormat GetExtension(this RequestedImageFormat format)
+        public static IImageFormat GetImageFormat(this RequestedImageFormat format)
         {
             switch (format)
             {

--- a/HiP-ThumbnailService/Controllers/ThumbnailsController.cs
+++ b/HiP-ThumbnailService/Controllers/ThumbnailsController.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -13,8 +12,6 @@ using Microsoft.Extensions.Options;
 using PaderbornUniversity.SILab.Hip.ThumbnailService.Arguments;
 using PaderbornUniversity.SILab.Hip.ThumbnailService.Utility;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Formats;
-using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.Primitives;
 

--- a/HiP-ThumbnailService/HiP-ThumbnailService.csproj
+++ b/HiP-ThumbnailService/HiP-ThumbnailService.csproj
@@ -20,10 +20,6 @@
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="appsettings.Development.json" />
-  </ItemGroup>
-
   <ProjectExtensions><VisualStudio><UserProperties /></VisualStudio></ProjectExtensions>
 
 </Project>


### PR DESCRIPTION
As discussed the size parameter can now be empty. In this case the service returns the original image (in the requested format) 