### PR TITLE
Refactored NuGet packaging

### DIFF
--- a/HiP-ThumbnailService.Sdk/HiP-ThumbnailService.Sdk.csproj
+++ b/HiP-ThumbnailService.Sdk/HiP-ThumbnailService.Sdk.csproj
@@ -9,7 +9,6 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
-
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />

--- a/NuGetPack.ps1
+++ b/NuGetPack.ps1
@@ -1,0 +1,10 @@
+$csproj = (ls *.Sdk\*.csproj).FullName
+Switch ("$env:Build_SourceBranchName")
+{
+    "master" { dotnet pack "$csproj" -o . }
+    "develop" { dotnet pack "$csproj" -o . --version-suffix "develop" }
+    default { exit }
+}
+$nupkg = (ls *.Sdk\*.nupkg).FullName
+dotnet --% nuget push "$nupkg" -k %MyGetKey% -s %NuGetFeed%
+$LASTEXITCODE = 0


### PR DESCRIPTION
According to the guidelines on Confluence, the packaging script is now part of the repository.